### PR TITLE
Tiny rename for AffineTransformation

### DIFF
--- a/src/datum_transformations.jl
+++ b/src/datum_transformations.jl
@@ -102,7 +102,7 @@ function GDA94_from_ITRF_Dawson2010(ITRF_year, epoch)
                       -Rz  1.0   Rx;
                        Ry  -Rx  1.0]
 
-    AffineTransformation(M, Vec(Tx,Ty,Tz))
+    AffineMap(M, Vec(Tx,Ty,Tz))
 end
 
 


### PR DESCRIPTION
CoordinateTransformations will use the new name in the tagged version 0.2.0 (https://github.com/JuliaLang/METADATA.jl/pull/5953)

Tests will fail until the tag is accepted, hopefully after that the churn in CoordinateTransformations will settle down a bit - I think we're converging on a design there now.