### PR TITLE
Updated to Julia 0.5 only support (and related deps)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 0.5
+  - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - julia: nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Geodesy"); Pkg.test("Geodesy"; coverage=true)'

--- a/README.md
+++ b/README.md
@@ -287,9 +287,8 @@ interconnected but conceptually distinct.  To emphasize:
 ### Coordinate types
 
 Geodesy provides several in-built coordinate storage types for convenience and
-safety. The philosophy is to avoid carrying around raw data in `Vector`s,
-*FixedSizeArray* `Vec`s or `Point`s with no concept of what coordinate system it
-is in.
+safety. The philosophy is to avoid carrying around raw data in generic containers
+like `Vector`s with no concept of what coordinate system it is in.
 
 ##### `LLA{T}` - latitude, longitude and altitude
 
@@ -306,7 +305,10 @@ is also provided. `LatLon` is currently the only supported 2D coordinate.
 ##### `ECEF{T}` - Earth-centered, Earth-fixed
 
 The global `ECEF` type stores Cartesian coordinates `x`, `y`, `z`, according to the
-[usual convention](https://en.wikipedia.org/wiki/ECEF).
+[usual convention](https://en.wikipedia.org/wiki/ECEF). Being a Cartesian frame,
+`ECEF` is a subtype of [StaticArrays](https://github.com/andyferris/StaticArrays.jl)'
+`StaticVector` and they can be added and subtracted with themselves and other
+vectors.
 
 ##### `UTM{T}` - universal transverse-Mercator
 
@@ -327,7 +329,7 @@ projection about the corresponding pole, otherwise `zone` is an integer between
 
 The `ENU` type is a local Cartesian coordinate that encodes a point's distance
 towards east `e`, towards north `n` and upwards `u` with respect to an
-unspecified origin.
+unspecified origin. Like `ECEF`, `ENU` is also a subtype of `StaticVector`.
 
 ### Geodetic Datums
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.4
-Compat
-CoordinateTransformations 0.2.0
-FixedSizeArrays
+julia 0.5-
+CoordinateTransformations 0.3.0
+StaticArrays 0.0.4

--- a/src/Geodesy.jl
+++ b/src/Geodesy.jl
@@ -3,8 +3,7 @@ __precompile__()
 module Geodesy
 
 using CoordinateTransformations
-using FixedSizeArrays
-using Compat
+using StaticArrays
 
 import CoordinateTransformations.transform_deriv,
        CoordinateTransformations.transform_deriv_params,

--- a/src/datum_transformations.jl
+++ b/src/datum_transformations.jl
@@ -98,11 +98,11 @@ function GDA94_from_ITRF_Dawson2010(ITRF_year, epoch)
     unitconv = [1e-3, 1e-3, 1e-3, 1e-9, mas2rad, mas2rad, mas2rad]
     Tx,Ty,Tz, Sc, Rx,Ry,Rz = unitconv .* (params .+ rates*dt)
 
-    M = (1+Sc) * @fsa [1.0  Rz  -Ry;
-                      -Rz  1.0   Rx;
-                       Ry  -Rx  1.0]
+    M = (1+Sc) * @SMatrix [1.0  Rz  -Ry;
+                          -Rz  1.0   Rx;
+                           Ry  -Rx  1.0]
 
-    AffineMap(M, Vec(Tx,Ty,Tz))
+    AffineMap(M, SVector(Tx,Ty,Tz))
 end
 
 
@@ -111,4 +111,3 @@ datum_shift_ECEF{Y}(itrf::ITRF{Y}, ::GDA94) = inv(GDA94_from_ITRF_Dawson2010(Y, 
 
 # TODO - time-based transformation!
 # make_datum_transform_ECEF{Y}(::ITRF{Y,Void}, ::GDA94) =
-

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -127,8 +127,8 @@ end
     end
 end
 
-@compat (::Type{ITRF{Year}}){Year}() = ITRF{Year,Void}(nothing)
-@compat (::Type{ITRF{Year}}){Year}(epoch) = ITRF{Year,typeof(epoch)}(epoch)
+(::Type{ITRF{Year}}){Year}() = ITRF{Year,Void}(nothing)
+(::Type{ITRF{Year}}){Year}(epoch) = ITRF{Year,typeof(epoch)}(epoch)
 
 Base.show{Y}(io::IO, ::ITRF{Y,Void}) = print(io,"ITRF{$Y}")
 Base.show{Y}(io::IO, itrf::ITRF{Y}) = print(io,"ITRF{$Y}($(itrf.epoch))")
@@ -179,4 +179,3 @@ const osgb36 = OSGB36()
 const nad27 = NAD27()
 const nad83 = NAD83()
 const gda94 = GDA94()
-

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -5,12 +5,12 @@ The Cartesian distance between points `a` and `b`. Uses `datum` to perform
 transformations as necessary, and unlike other *Geodesy* functions, this defaults
 to use the common WGS-84 datum for convenience.
 """
-distance{T <: FixedVector}(a::T, b::T) = norm(a-b)
+distance{T <: AbstractVector}(a::T, b::T) = vecnorm(a-b)
 
 # Automatic transformations to ECEF
 # Uses wgs84 datum as a default. In most cases, the datum choice will only make
 # a small difference to the answer. Nevertheless, is this acceptable?
-distance{T <: FixedVector}(a::T, b::T, datum) = distance(a, b)
+distance{T <: AbstractVector}(a::T, b::T, datum) = distance(a, b)
 distance(a::LLA, b, datum = wgs84) = distance(ECEFfromLLA(datum)(a), b, datum)
 distance(a::ECEF, b::LLA, datum = wgs84) = distance(a, ECEFfromLLA(datum)(b), datum)
 distance(a::LatLon, b, datum = wgs84) = distance(ECEFfromLLA(datum)(LLA(a)), b, datum)

--- a/src/ellipsoids.jl
+++ b/src/ellipsoids.jl
@@ -11,14 +11,14 @@ immutable Ellipsoid
                       # of the const instance in the package!
 end
 
-function Ellipsoid(; a::@compat(AbstractString)="", b::@compat(AbstractString)="", f_inv::@compat(AbstractString)="", name=:UNKNOWN)
+function Ellipsoid(; a::String="", b::String="", f_inv::String="", name=:UNKNOWN)
     if isempty(a) || isempty(b) == isempty(f_inv)
         throw(ArgumentError("Specify parameter 'a' and either 'b' or 'f_inv'"))
     end
     if isempty(b)
-        _ellipsoid_af(@compat(parse(BigFloat,a)), @compat(parse(BigFloat,f_inv)), name)
+        _ellipsoid_af(parse(BigFloat, a), parse(BigFloat, f_inv), name)
     else
-        _ellipsoid_ab(@compat(parse(BigFloat,a)), @compat(parse(BigFloat,b)), name)
+        _ellipsoid_ab(parse(BigFloat, a), parse(BigFloat, b), name)
     end
 end
 

--- a/src/points.jl
+++ b/src/points.jl
@@ -47,7 +47,7 @@ Base.isapprox(ll1::LatLon, ll2::LatLon; atol = 1e-6, kwargs...) = isapprox(ll1.l
 Earth-Centered-Earth-Fixed (ECEF) coordinates. A global Cartesian coordinate
 system rotating with the Earth.
 """
-immutable ECEF{T} <: FixedVectorNoTuple{3,Float64}
+immutable ECEF{T} <: FieldVector{T}
     x::T
     y::T
     z::T
@@ -60,7 +60,7 @@ Base.show(io::IO, ecef::ECEF) = print(io, "ECEF($(ecef.x), $(ecef.y), $(ecef.z))
 
 East-North-Up (ENU) coordinates. A local Cartesian coordinate system, linearized about a reference point.
 """
-immutable ENU{T} <: FixedVectorNoTuple{3,Float64}
+immutable ENU{T} <: FieldVector{T}
     e::T
     n::T
     u::T

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -45,7 +45,7 @@ end
 LLAfromECEF(datum::Datum) = LLAfromECEF(ellipsoid(datum))
 
 
-@compat function (trans::LLAfromECEF)(ecef::ECEF)
+ function (trans::LLAfromECEF)(ecef::ECEF)
     # Ported to Julia by Andy Ferris, 2016 and re-released under MIT license.
     #/**
     # * \file Geocentric.cpp
@@ -172,7 +172,7 @@ Base.show(io::IO, trans::ECEFfromLLA) = print(io, "ECEFfromLLA($(trans.el))")
 ECEFfromLLA(datum::Datum) = ECEFfromLLA(ellipsoid(datum))
 
 
-@compat function (trans::ECEFfromLLA)(lla::LLA)
+function (trans::ECEFfromLLA)(lla::LLA)
     ϕdeg, λdeg, h = lla.lat, lla.lon, lla.alt
 
     sinϕ, cosϕ = sind(ϕdeg), cosd(ϕdeg)
@@ -218,7 +218,7 @@ Base.show(io::IO, trans::ENUfromECEF) = print(io, "ENUfromECEF($(trans.origin), 
 Base.isapprox(t1::ENUfromECEF, t2::ENUfromECEF; kwargs...) = isapprox(t1.origin, t2.origin; kwargs...) && isapprox(t1.lat, t2.lat; kwargs...) && isapprox(t1.lon, t2.lon; kwargs...)
 
 
-@compat function (trans::ENUfromECEF)(ecef::ECEF)
+function (trans::ENUfromECEF)(ecef::ECEF)
     ϕdeg, λdeg = trans.lat, trans.lon
 
     ∂x = ecef.x - trans.origin.x
@@ -263,7 +263,7 @@ end
 Base.show(io::IO, trans::ECEFfromENU) = print(io, "ECEFfromENU($(trans.origin), lat=$(trans.lat)°, lon=$(trans.lon)°)")
 Base.isapprox(t1::ECEFfromENU, t2::ECEFfromENU; kwargs...) = isapprox(t1.origin, t2.origin; kwargs...) && isapprox(t1.lat, t2.lat; kwargs...) && isapprox(t1.lon, t2.lon; kwargs...)
 
-@compat function (trans::ECEFfromENU)(enu::ENU)
+function (trans::ECEFfromENU)(enu::ENU)
     ϕdeg, λdeg = trans.lat, trans.lon
 
     # Compute rotation matrix
@@ -330,7 +330,7 @@ LLAfromUTM(zone::UInt8, h, d) = LLAfromUTM(UInt8(zone), h, TransverseMercator(d)
 LLAfromUTM(zone::Integer, h, d) = LLAfromUTM(UInt8(zone), h, d)
 Base.show(io::IO, trans::LLAfromUTM) = print(io, "LLAfromUTM(zone=$(trans.zone == 0 ? "polar" : trans.zone) ($(trans.isnorth ? "north" : "south")), $(trans.datum))")
 
-@compat function (trans::LLAfromUTM)(utm::UTM)
+function (trans::LLAfromUTM)(utm::UTM)
     if trans.zone == 0
         # Do inverse steriographic projection
         k0 = 0.994
@@ -370,7 +370,7 @@ UTMfromLLA(zone::UInt8, h, d) = UTMfromLLA(zone, h, TransverseMercator(d), d)
 UTMfromLLA(zone::Integer, h, d) = UTMfromLLA(UInt8(zone), h, d)
 Base.show(io::IO, trans::UTMfromLLA) = print(io, "UTMfromLLA(zone=$(trans.zone == 0 ? "polar" : trans.zone) ($(trans.isnorth ? "north" : "south")), $(trans.datum))")
 
-@compat function (trans::UTMfromLLA)(lla::LLA)
+function (trans::UTMfromLLA)(lla::LLA)
     if trans.zone == 0
         # Do polar steriographic projection
         k0 = 0.994
@@ -435,7 +435,7 @@ LLAfromUTMZ(datum) = LLAfromUTMZ(TransverseMercator(datum), datum)
 Base.show(io::IO, trans::LLAfromUTMZ) = print(io, "LLAfromUTMZ($(trans.datum))")
 
 
-@compat function (trans::LLAfromUTMZ)(utm::UTMZ)
+function (trans::LLAfromUTMZ)(utm::UTMZ)
     if utm.zone == 0
         # Do inverse steriographic projection
         k0 = 0.994
@@ -474,10 +474,8 @@ UTMZfromLLA(datum) = UTMZfromLLA(TransverseMercator(datum), datum)
 Base.show(io::IO, trans::UTMZfromLLA) = print(io, "UTMZfromLLA($(trans.datum))")
 
 
-@compat function (trans::UTMZfromLLA)(lla::LLA)
+function (trans::UTMZfromLLA)(lla::LLA)
     (zone, isnorth) = utm_zone(lla)
-    zone::Int64
-    isnorth::Bool
     if zone == 0
         # Do polar steriographic projection
         k0 = 0.994
@@ -534,8 +532,8 @@ UTMfromUTMZ{D}(zone::Integer, h, d::D) = UTMfromUTMZ{D}(UInt8(zone), h, d)
 Base.show(io::IO, trans::UTMfromUTMZ) = print(io, "UTMfromUTMZ(zone=$(trans.zone == 0 ? "polar" : trans.zone) ($(trans.isnorth ? "north" : "south")), $(trans.datum))")
 #Base.show(io::IO, trans::UTMfromUTMZ) = print(io, "UTMfromUTMZ(zone=$(trans.zone == 0 ? "polar" : trans.zone) ($(trans.isnorth ? "north" : "south")))")
 
-@compat (trans::UTMZfromUTM)(utm::UTM) = UTMZ(utm.x, utm.y, utm.z, trans.zone, trans.isnorth)
-@compat function (trans::UTMfromUTMZ)(utm::UTMZ)
+(trans::UTMZfromUTM)(utm::UTM) = UTMZ(utm.x, utm.y, utm.z, trans.zone, trans.isnorth)
+function (trans::UTMfromUTMZ)(utm::UTMZ)
     if trans.zone == utm.zone && trans.isnorth == utm.isnorth
         UTM(utm.x, utm.y, utm.z)
     else

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-BaseTestNext

--- a/test/datum_transformations.jl
+++ b/test/datum_transformations.jl
@@ -14,9 +14,9 @@ using CoordinateTransformations
 
         # Test inverse
         epoch = Date(2010,6,16)
-        T = datum_shift_ECEF(ITRF{2008}(epoch), GDA94) ∘ datum_shift_ECEF(GDA94, ITRF{2008}(epoch))
-        @test transformation_matrix(T) ≈ eye(3)
-        @test isapprox(translation_vector(T), zeros(3), atol=10*eps())
+        trans = datum_shift_ECEF(ITRF{2008}(epoch), GDA94) ∘ datum_shift_ECEF(GDA94, ITRF{2008}(epoch))
+        @test trans.m ≈ eye(3)
+        @test isapprox(trans.v, zeros(3), atol=10*eps())
     end
 
     @testset "ITRS realizations" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Geodesy
-using BaseTestNext
+using Base.Test
 
 ################################################
 ### Helpers for testing approximate equality ###


### PR DESCRIPTION
Now we use the Julia 0.5-only dependencies StaticArrays and CoordinateTransformations 0.3.0 (soon to be tagged). We will release a new minor version of Geodesy shortly after this merges.