### PR TITLE
CI tests against Julia 0.6, macOS, and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: julia
 os:
+  - osx
   - linux
 julia:
   - 0.5

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | **Package Evaluator**                                           | **Build Status**                                                                                |
 |:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![0.4 package tests](http://pkg.julialang.org/badges/Geodesy_0.4.svg)](http://pkg.julialang.org/?pkg=Geodesy) [![0.5 package tests](http://pkg.julialang.org/badges/Geodesy_0.5.svg)](http://pkg.julialang.org/?pkg=Geodesy) | [![master build](https://travis-ci.org/JuliaGeo/Geodesy.jl.svg?branch=master)](https://travis-ci.org/JuliaGeo/Geodesy.jl) [![master coverage](http://img.shields.io/coveralls/JuliaGeo/Geodesy.jl.svg)](https://coveralls.io/r/JuliaGeo/Geodesy.jl) |
+| [![0.5 package tests](http://pkg.julialang.org/badges/Geodesy_0.5.svg)](http://pkg.julialang.org/?pkg=Geodesy) [![0.6 package tests](http://pkg.julialang.org/badges/Geodesy_0.6.svg)](http://pkg.julialang.org/?pkg=Geodesy) | [![Linux/macOS](https://travis-ci.org/JuliaGeo/Geodesy.jl.svg?branch=master)](https://travis-ci.org/JuliaGeo/Geodesy.jl) [![Windows](https://ci.appveyor.com/api/projects/status/github/NgYeeSian/Geodesy.jl?svg=true)](https://ci.appveyor.com/project/NgYeeSian/geodesy-jl) [![Coverage](http://img.shields.io/coveralls/JuliaGeo/Geodesy.jl.svg)](https://coveralls.io/r/JuliaGeo/Geodesy.jl) |
 
 **Geodesy** is a Julia package for working with points in various world and
 local coordinate systems. The primary feature of *Geodesy* is to define and

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,7 @@
 julia 0.5-
 CoordinateTransformations 0.3.0
-StaticArrays 0.0.4
+
+# Enforce that:
+# - Julia 0.6 only using StaticArrays 0.5.0 and up
+# - Julia 0.5 uses StaticArrays between 0.0.4 and 0.4.0-
+StaticArrays 0.0.4 0.4.0- 0.5.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+environment:
+  matrix:
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $env:JULIA_URL,
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"Geodesy\"); Pkg.build(\"Geodesy\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"Geodesy\")"

--- a/src/points.jl
+++ b/src/points.jl
@@ -2,6 +2,11 @@
 ### Point Types ###
 ###################
 
+# See the REQUIRE file for details.
+@static if VERSION >= v"0.6"
+    const FieldVector{T} = StaticArrays.FieldVector{3, T}
+end
+
 """
     LLA(lat, lon, alt = 0.0)
     LLA(lat = ϕ, lon = Θ, alt = h)


### PR DESCRIPTION
Appveyor will need to be enabled for this package. Probably one of the maintainers should enable it. I can add the badges to the README here once I know the Appveyor URL to use.