### PR TITLE
Fix typo in show method of OSGB36

### DIFF
--- a/src/datums.jl
+++ b/src/datums.jl
@@ -143,7 +143,7 @@ ellipsoid(::Type{D}) where {D<:ITRF} = grs80
 `OSGB36` - Datum for Ordinance Survey of Great Britain, 1936
 """
 struct OSGB36 <: Datum; end
-Base.show(io::IO, ::OSGB36) = print(io,"osbg84")
+Base.show(io::IO, ::OSGB36) = print(io,"osgb36")
 ellipsoid(::Union{OSGB36,Type{OSGB36}}) = airy1830
 
 

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -169,6 +169,7 @@ ellipsoid(::Union{NAD83,Type{NAD83}}) = grs80
 `GDA94` - Geocentric Datum of Australia, 1994
 """
 struct GDA94 <: Datum; end
+Base.show(io::IO, ::GDA94) = print(io,"gda94")
 ellipsoid(::Union{GDA94,Type{GDA94}})   = grs80
 
 

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -19,4 +19,14 @@
     @test (LLAfromECEF(nad83); true)
     @test (LLAfromECEF(osgb36); true)
     @test (LLAfromECEF(gda94); true)
+
+    # Show methods for datums
+    @test sprint(show, WGS84()) == "WGS84"
+    @test sprint(show, WGS84{0}()) == "WGS84 (G0)"
+    @test sprint(show, ITRF{1990}()) == "ITRF{1990}"
+    @test sprint(show, ITRF{1990}(1998)) == "ITRF{1990}(1998)"
+    @test sprint(show, OSGB36()) == "osgb36"
+    @test sprint(show, NAD27()) == "nad27"
+    @test sprint(show, NAD83()) == "nad83"
+    @test sprint(show, GDA94()) == "gda94"
 end


### PR DESCRIPTION
I assume that the desired output of `Base.show(io, ::OSGB36)` is indeed 'osgb36' rather than 'osbg84', but if I'm wrong then no matter.

I'm also not sure how to test `show` methods in general, so if that is important I'd be very grateful for any guidance.