### PR TITLE
Fix UndefVar in (::LLAfromECEF) and document ECEF->LLA conversion convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,10 @@ The `LLAfromECEF` and `ECEFfromLLA` transformations require an ellipsoidal datum
 to perform the conversion. The exact transformation is performed in both directions,
 using a port the ECEF → LLA transformation from *GeographicLib*.
 
+Note that in some cases where points are very close to the centre of the ellipsoid,
+multiple equivalent `LLA` points are valid solutions to the transformation problem.
+Here, as in *GeographicLib*, the point with the greatest altitude is chosen.
+
 #### Between `LLA` and `UTM`/`UTMZ`
 
 The `LLAfromUTM(Z)` and `UTM(Z)fromLLA` transformations also require an

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -145,7 +145,7 @@ LLAfromECEF(datum::Datum) = LLAfromECEF(ellipsoid(datum))
             H = hypot(zz, xx)
             sphi = zz / H
             cphi = xx / H
-            if (Z < 0)
+            if (ecef.z < 0)
                 sphi = -sphi # for tiny negative Z (not for prolate)
             end
             h = - trans.a * (trans.f >= 0 ? trans.e2m : 1.0) * H / trans.e2a

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -58,6 +58,8 @@
     @test enu ≈ ENU(-6103.186938282723, 10222.54767562731, -295.55857190545794)
     @test ecef_enu(ENU(-6103.186938282723, 10222.54767562731, -295.55857190545794)) ≈ ecef
 
+    # https://github.com/JuliaGeo/Geodesy.jl/issues/49
+    @test LLA(ECEF(1, 0, 0), wgs84) ≈ LLA(89.99866260445, 0.00000000000, -6356752.314234)
 
     # Inverses
     @test inv(ecef_lla) == lla_ecef


### PR DESCRIPTION
Before this fix, converting from ECEF to LLA coordinates with
points very near to the centre of the ellipsoid and with a small
value of z (e.g., (x, y, z) = (4e4, 0, 0) for WGS84) would throw
an UndefVarError.  With this fix, the same LLA point is returned
as is done by GeographicLib.  However, in this case multiple
solutions are present and this fix also documents the choice made.

- Change variable name to avoid UndefVarError
- Add test based off GeographicLib values
- Add explanation of which of several solutions are chosen in the
  ECEF->LLA conversion to the README.md file.