### PR TITLE
Rename distance -> euclidean_distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,14 +446,15 @@ counterparts.
 
 ### Distance
 
-Currently, the only defined distance measure is the Cartesian distance,
-`distance(x, y, [datum = wgs84])`, which works for all combinations of types for
-`x` and `y` - except that the UTM zone and hemisphere must also be provided
-for `UTM` types, as in `distance(utm1, utm2, zone, hemisphere, [datum = wgs84])`
-(the Cartesian distance for `UTM` types is not approximated, but achieved via
-conversion to `ECEF`).
+Currently, the only defined distance measure is the straight-line or [Euclidean
+distance](https://en.wikipedia.org/wiki/Euclidean_distance),
+`euclidean_distance(x, y, [datum = wgs84])`, which works for all combinations
+of types for `x` and `y` - except that the UTM zone and hemisphere must also be
+provided for `UTM` types, as in `euclidean_distance(utm1, utm2, zone,
+hemisphere, [datum = wgs84])` (the Cartesian distance for `UTM` types is not
+approximated, but achieved via conversion to `ECEF`).
 
-This is the only function currently in
-*Geodesy* which takes a default datum, and *should* be relatively accurate for
-close points where Cartesian distances may be most important. Future work
-may focus on geodesics and related calculations (contributions welcome!).
+This is the only function currently in *Geodesy* which takes a default datum,
+and *should* be relatively accurate for close points where Euclidean distances
+are most important. Future work may focus on geodesics and related calculations
+(contributions welcome!).

--- a/src/Geodesy.jl
+++ b/src/Geodesy.jl
@@ -34,7 +34,7 @@ export
     GDA94, gda94,
 
     # Methods
-    distance,
+    euclidean_distance,
 
     # transformation methods
     transform_deriv, transform_deriv_params, compose, ∘,

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -1,36 +1,34 @@
 using LinearAlgebra: norm
 
 """
-    distance(a, b, [datum = wgs84])
+    euclidean_distance(a, b, [datum = wgs84])
 
-The Cartesian distance between points `a` and `b`. Uses `datum` to perform
-transformations as necessary, and unlike other *Geodesy* functions, this defaults
-to use the common WGS-84 datum for convenience.
+The straight-line distance between points `a` and `b`. Uses `datum` to perform
+transformations as necessary, and unlike other *Geodesy* functions, this
+defaults to use the common WGS-84 datum for convenience.
 """
-distance(a::T, b::T) where {T <: AbstractVector} = norm(a-b)
+euclidean_distance(a::T, b::T) where {T <: AbstractVector} = norm(a-b)
 
 # Automatic transformations to ECEF
 # Uses wgs84 datum as a default. In most cases, the datum choice will only make
 # a small difference to the answer. Nevertheless, is this acceptable?
-distance(a::T, b::T, datum) where {T <: AbstractVector} = distance(a, b)
-distance(a::LLA, b, datum = wgs84) = distance(ECEFfromLLA(datum)(a), b, datum)
-distance(a::ECEF, b::LLA, datum = wgs84) = distance(a, ECEFfromLLA(datum)(b), datum)
-distance(a::LatLon, b, datum = wgs84) = distance(ECEFfromLLA(datum)(LLA(a)), b, datum)
-distance(a::ECEF, b::LatLon, datum = wgs84) = distance(a, ECEFfromLLA(datum)(LLA(b)), datum)
-distance(a::UTMZ, b, datum = wgs84) = distance(ECEFfromUTMZ(datum)(a), b, datum)
-distance(a::ECEF, b::UTMZ, datum = wgs84) = distance(a, ECEFfromUTMZ(datum)(b), datum)
+euclidean_distance(a::T, b::T, datum) where {T <: AbstractVector} = euclidean_distance(a, b)
+euclidean_distance(a::LLA, b, datum = wgs84) = euclidean_distance(ECEFfromLLA(datum)(a), b, datum)
+euclidean_distance(a::ECEF, b::LLA, datum = wgs84) = euclidean_distance(a, ECEFfromLLA(datum)(b), datum)
+euclidean_distance(a::LatLon, b, datum = wgs84) = euclidean_distance(ECEFfromLLA(datum)(LLA(a)), b, datum)
+euclidean_distance(a::ECEF, b::LatLon, datum = wgs84) = euclidean_distance(a, ECEFfromLLA(datum)(LLA(b)), datum)
+euclidean_distance(a::UTMZ, b, datum = wgs84) = euclidean_distance(ECEFfromUTMZ(datum)(a), b, datum)
+euclidean_distance(a::ECEF, b::UTMZ, datum = wgs84) = euclidean_distance(a, ECEFfromUTMZ(datum)(b), datum)
 
 """
-    distance(utm1, utm2, zone, isnorth, [datum = wgs84])
-    distance(a, utm2, zone, isnorth, [datum = wgs84])
-    distance(utm1, b, zone, isnorth, [datum = wgs84])
+    euclidean_distance(utm1, utm2, zone, isnorth, [datum = wgs84])
+    euclidean_distance(a, utm2, zone, isnorth, [datum = wgs84])
+    euclidean_distance(utm1, b, zone, isnorth, [datum = wgs84])
 
 If one or both points are UTM, we need the zone (and particularly the hemisphere,
-isnorth = true/false) to determine the Cartesian distance.
+isnorth = true/false) to determine the Euclidean distance.
 """
-distance(a::UTM, b::UTM, zone::Integer, isnorth::Bool, datum = wgs84) = distance(ECEFfromUTM(zone, isnorth, datum)(a), ECEFfromUTM(zone, isnorth, datum)(b), datum)
-distance(a, b::UTM, zone::Integer, isnorth::Bool, datum = wgs84) = distance(a, ECEFfromUTM(zone, isnorth, datum)(b), datum)
-distance(a::UTM, b, zone::Integer, isnorth::Bool, datum = wgs84) = distance(ECEFfromUTM(zone, isnorth, datum)(a), b, datum)
+euclidean_distance(a::UTM, b::UTM, zone::Integer, isnorth::Bool, datum = wgs84) = euclidean_distance(ECEFfromUTM(zone, isnorth, datum)(a), ECEFfromUTM(zone, isnorth, datum)(b), datum)
+euclidean_distance(a, b::UTM, zone::Integer, isnorth::Bool, datum = wgs84) = euclidean_distance(a, ECEFfromUTM(zone, isnorth, datum)(b), datum)
+euclidean_distance(a::UTM, b, zone::Integer, isnorth::Bool, datum = wgs84) = euclidean_distance(ECEFfromUTM(zone, isnorth, datum)(a), b, datum)
 
-
-# Also add geodesic distances here

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -82,18 +82,18 @@
             lla1 = randLLA()
             lla2 = randLLA()
 
-            d = distance(lla1, lla2)
+            d = euclidean_distance(lla1, lla2)
 
             ecef1 = ECEF(lla1, wgs84)
             ecef2 = ECEF(lla2, wgs84)
 
-            @test distance(ecef1, ecef2) ≈ sqrt((ecef1.x - ecef2.x)^2 + (ecef1.y - ecef2.y)^2 + (ecef1.z - ecef2.z)^2)
-            @test distance(ecef1, ecef2) ≈ d
+            @test euclidean_distance(ecef1, ecef2) ≈ sqrt((ecef1.x - ecef2.x)^2 + (ecef1.y - ecef2.y)^2 + (ecef1.z - ecef2.z)^2)
+            @test euclidean_distance(ecef1, ecef2) ≈ d
 
             utmz1 = UTMZ(lla1, wgs84)
             utmz2 = UTMZ(lla2, wgs84)
 
-            @test distance(utmz1, utmz2) ≈ d
+            @test euclidean_distance(utmz1, utmz2) ≈ d
 
             if utmz1.zone == utmz2.zone && utmz1.isnorth == utmz2.isnorth
                 number_of_utm_distance_tests += 1
@@ -104,15 +104,15 @@
                 zone = utmz1.zone
                 isnorth = utmz1.isnorth
 
-                @test distance(utm1,  utm2,  zone, isnorth) ≈ d
-                @test distance(utm1,  ecef2, zone, isnorth) ≈ d
-                @test distance(ecef1, utm2,  zone, isnorth) ≈ d
+                @test euclidean_distance(utm1,  utm2,  zone, isnorth) ≈ d
+                @test euclidean_distance(utm1,  ecef2, zone, isnorth) ≈ d
+                @test euclidean_distance(ecef1, utm2,  zone, isnorth) ≈ d
             end
 
             enu000 = ENU(0.0, 0.0, 0.0)
             enu = ENU(ecef1, ecef2, wgs84)
 
-            @test distance(enu, enu000) ≈ d
+            @test euclidean_distance(enu, enu000) ≈ d
         end
         @test number_of_utm_distance_tests > 0
     end


### PR DESCRIPTION
As mentioned in #59, I think it's a bit iffy to be exporting a completely generic name like `distance` from a package where there's more than one type of relevant distance function. And furthermore, where users may reasonably guess `Geodesy.distance` to be the geodetic distance, which it's not!

So I propose we just rename this to something more explicit.