### PR TITLE
promote x,y,z in UTMZ to avoid StackOverflowError

### DIFF
--- a/src/points.jl
+++ b/src/points.jl
@@ -120,7 +120,7 @@ struct UTMZ{T <: Number}
     isnorth::Bool # which hemisphere
 end
 UTMZ(x::T, y::T, zone::Integer, isnorth::Bool) where {T} = UTMZ(x, y, zero(T), UInt8(zone), isnorth)
-UTMZ(x, y, z, zone::Integer, isnorth::Bool) = UTMZ(x, y, z, UInt8(zone), isnorth)
+UTMZ(x, y, z, zone::Integer, isnorth::Bool) = UTMZ(promote(x, y, z)..., UInt8(zone), isnorth)
 UTMZ(utm::UTM, zone::Integer, isnorth::Bool) = UTMZ(utm.x, utm.y, utm.z, UInt8(zone), isnorth)
 UTM(utmz::UTMZ) = UTM(utmz.x, utmz.y, utmz.z)
 Base.isapprox(utm1::UTMZ, utm2::UTMZ; atol = 1e-6, kwargs...) = (utm1.zone == utm2.zone) & (utm1.isnorth == utm2.isnorth) & isapprox(utm1.x, utm2.x; atol = atol, kwargs...) & isapprox(utm1.y, utm2.y; atol = atol, kwargs...) & isapprox(utm1.z, utm2.z; atol = atol, kwargs...) # atol in metres (1μm)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -36,7 +36,7 @@
         @test ENU(utm, z, h, lla_ref, wgs84) ≈ enu
 
         # LLA <-> UTMZ
-        utmz = UTMZ(327412.48528248386, 4.692686244318043e6, 0.0, z, h)
+        utmz = UTMZ(327412.48528248386, 4.692686244318043e6, 0, z, h)
         @test UTMZ(lla, wgs84) ≈ utmz
         @test LLA(utmz, wgs84) ≈ lla
 


### PR DESCRIPTION
Fixes #62.