### PR TITLE
Fix UPS conversions for exact south/north poles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Geodesy"
 uuid = "0ef565a4-170c-5f04-8de2-149903a85f3d"
 license = "MIT"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/src/polar_stereographic.jl
+++ b/src/polar_stereographic.jl
@@ -16,6 +16,10 @@ function polarst_fwd(northp::Bool, k0::Float64, tm::TransverseMercator, lat, lon
     lat = LatFix(lat) * (northp ? 1 : -1)
 
     tau = tand(lat)
+    if abs(lat) == 90
+        overflow = one(tau)/eps(typeof(tau))^2
+        tau = sign(lat)*overflow
+    end
     secphi = hypot(1.0, tau)
     taup = taupf(tau, tm.e2) # TODO revert to C++ es here?
     rho = hypot(1.0, taup) + abs(taup)

--- a/test/polar_stereographic.jl
+++ b/test/polar_stereographic.jl
@@ -2,6 +2,19 @@
 
     tm = Geodesy.TransverseMercator(wgs84)
 
+    # Exact north pole
+    lat = 90.0
+    lon = 180.0
+    x = 2000000.0 - 2e6
+    y = 2000000.0 - 2e6
+    northpole = true
+
+    (x2, y2, γ, k) = Geodesy.polarst_fwd(northpole, 0.994, tm, lat, lon)
+    @test (x2, y2) ≈ (x, y)
+
+    (lat2, lon2, γ, k) = Geodesy.polarst_inv(northpole, 0.994, tm, x, y)
+    @test (lat2, lon2) ≈ (lat, lon)
+
     # Data generated independely from Charles Karney's http://geographiclib.sourceforge.net/cgi-bin/GeoConvert?input=89+1&zone=0&prec=9&option=Submit
 
     lat = 89.0
@@ -92,6 +105,19 @@
     lon = -89.0
     x = 1555799.234876368 - 2e6
     y = 2007753.553196397 - 2e6
+    northpole = false
+
+    (x2, y2, γ, k) = Geodesy.polarst_fwd(northpole, 0.994, tm, lat, lon)
+    @test (x2, y2) ≈ (x, y)
+
+    (lat2, lon2, γ, k) = Geodesy.polarst_inv(northpole, 0.994, tm, x, y)
+    @test (lat2, lon2) ≈ (lat, lon)
+
+    # Exact south pole
+    lat = -90.0
+    lon = 0.0
+    x = 2000000.0 - 2e6
+    y = 2000000.0 - 2e6
     northpole = false
 
     (x2, y2, γ, k) = Geodesy.polarst_fwd(northpole, 0.994, tm, lat, lon)


### PR DESCRIPTION
This just copies the overflow handling from GeographicLib.

Fixes #57