### PR TITLE
add GDA2020 type

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ National datums include
 * `OSGB36` - Ordnance Survey of Great Britain of 1936.
 * `NAD27`, `NAD83` - North American Datums of 1927 and 1983, respectively
 * `GDA94` - Geocentric Datum of Australia, 1994.
+* `GDA2020` - Geocentric Datum of Australia, 2020.
 
 Datums may also be passed to coordinate transformation constructors such as
 transverse-Mercator and polar-stereographic projections in which case the

--- a/src/Geodesy.jl
+++ b/src/Geodesy.jl
@@ -32,6 +32,7 @@ export
     NAD83, nad83,
     GRS80, grs80,
     GDA94, gda94,
+    GDA2020, gda2020,
 
     # Methods
     euclidean_distance,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -173,6 +173,13 @@ Base.show(io::IO, ::GDA94) = print(io,"gda94")
 ellipsoid(::Union{GDA94,Type{GDA94}})   = grs80
 
 
+"""
+`GDA2020` - Geocentric Datum of Australia, 2020
+"""
+struct GDA2020 <: Datum; end
+Base.show(io::IO, ::GDA2020) = print(io,"gda2020")
+ellipsoid(::Union{GDA2020,Type{GDA2020}})   = grs80
+
 #-------------------------------------------------------------------------------
 # Datum instances
 const wgs84 = WGS84()
@@ -180,3 +187,4 @@ const osgb36 = OSGB36()
 const nad27 = NAD27()
 const nad83 = NAD83()
 const gda94 = GDA94()
+const gda2020 = GDA2020()

--- a/src/transverse_mercator.jl
+++ b/src/transverse_mercator.jl
@@ -390,6 +390,7 @@ TransverseMercator(::WGS84) = wgs84_tm
 TransverseMercator(::OSGB36) = airy1830_tm
 TransverseMercator(::NAD27) = clarke1866_tm
 TransverseMercator(::GDA94) = grs80_tm
+TransverseMercator(::GDA2020) = grs80_tm
 
 # // Engsager and Poder (2007) use trigonometric series to convert between phi
 # // and phip.  Here are the series...

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -5,12 +5,14 @@
     @test ellipsoid(NAD83) == grs80
     @test ellipsoid(OSGB36) == airy1830
     @test ellipsoid(GDA94) == grs80
+    @test ellipsoid(GDA2020) == grs80
 
     # Check transverse-Mercator pre-calculations
     @test Geodesy.TransverseMercator(WGS84) == Geodesy.wgs84_tm
     @test Geodesy.TransverseMercator(NAD27) == Geodesy.clarke1866_tm
     @test Geodesy.TransverseMercator(OSGB36) == Geodesy.airy1830_tm
     @test Geodesy.TransverseMercator(GDA94) == Geodesy.grs80_tm
+    @test Geodesy.TransverseMercator(GDA2020) == Geodesy.grs80_tm
 
     # The LLAfromECEF aren't pre-cached, as yet. Probably should just create a
     # large ellispoid thingie for all of them to share...
@@ -19,6 +21,7 @@
     @test (LLAfromECEF(nad83); true)
     @test (LLAfromECEF(osgb36); true)
     @test (LLAfromECEF(gda94); true)
+    @test (LLAfromECEF(gda2020); true)
 
     # Show methods for datums
     @test sprint(show, WGS84()) == "WGS84"
@@ -29,4 +32,5 @@
     @test sprint(show, NAD27()) == "nad27"
     @test sprint(show, NAD83()) == "nad83"
     @test sprint(show, GDA94()) == "gda94"
+    @test sprint(show, GDA2020()) == "gda2020"
 end


### PR DESCRIPTION
Simply creates a new GDA2020 datum by copying GDA94, as they use the same ellipsoid. Alternatively one could simply use the GDA94 datum when their data is in GDA2020, but this would be rather confusing for many.