### PR TITLE
Updates after renaming default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
 jobs:


### PR DESCRIPTION
Updates references from `master` to `main` after the default branch rename. This includes GitHub Actions workflow triggers.

This PR was created with AI assistance.